### PR TITLE
fix(nvim): use catppuccin lualine utility theme

### DIFF
--- a/dot_config/nvim/lua/plugins/lualine.lua
+++ b/dot_config/nvim/lua/plugins/lualine.lua
@@ -4,11 +4,12 @@ return {
 	"nvim-lualine/lualine.nvim",
 	dependencies = {
 		"lewis6991/gitsigns.nvim",
+		"catppuccin/nvim",
 	},
 	event = { "BufReadPost", "BufAdd", "BufNewFile" },
 	config = function()
 		local lualine = require("lualine")
-		local catppuccined = require("lualine.themes.catppuccin")
+		local catppuccined = require("catppuccin.utils.lualine")()
 
 		local palette = require("catppuccin.palettes").get_palette()
 		local segment = { fg = palette.subtext1, bg = palette.surface1 }


### PR DESCRIPTION
- add `catppuccin/nvim` as an explicit lualine dependency
- switch lualine theme loading to `catppuccin.utils.lualine`