### PR TITLE
fix: npm config env warning

### DIFF
--- a/dot_config/zsh/dot_zshenv
+++ b/dot_config/zsh/dot_zshenv
@@ -89,10 +89,9 @@ export KERAS_HOME="$XDG_CONFIG_HOME/keras"
 export NODE_REPL_HISTORY="$XDG_STATE_HOME/node_history"
 
 # npm
-export NPM_CONFIG_DIR="$XDG_CONFIG_HOME/npm"
 export NPM_DATA_DIR="$XDG_DATA_HOME/npm"
 export NPM_CACHE_DIR="$XDG_CACHE_HOME/npm"
-export NPM_CONFIG_USERCONFIG="$NPM_CONFIG_DIR/npmrc"
+export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
 
 if (( $+commands[nvim] )); then
   typeset -gx EDITOR=nvim


### PR DESCRIPTION
## Summary
- Remove the custom `NPM_CONFIG_DIR` environment variable so npm does not treat it as an unknown `dir` config
- Point `NPM_CONFIG_USERCONFIG` directly at the XDG npmrc path

## Verification
- Confirmed `ssh -T git@github.com` authenticates as `oyoshot`
- `git diff --check -- dot_config/zsh/dot_zshenv`