### PR TITLE
chore(tmux): remove tmux-continuum and tmux-resurrect

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -144,16 +144,9 @@ if -b '[ -c /dev/clipboard ]' 'bind y run -b "tmux save-buffer - > /dev/clipboar
 set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-battery'
-set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-cpu'
-set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'yardnsm/tmux-1password'
-
-# Continuum / Resurrect
-set -g @continuum-restore 'on'
-set -g @continuum-boot 'off'
-set -g @continuum-boot-options 'kitty'
 
 # Configure Cpu
 set -g @cpu_percentage_format "%03d%%"


### PR DESCRIPTION
## Summary
- `tmux-continuum` / `tmux-resurrect` プラグインと、それに紐づく `@continuum-*` 設定を削除
- 自動セーブ／自動リストアは実質「ペイン構成と cwd」しか戻せず、zoxide/ghq の popup でセッションを即座に立てられる現状の構成では恩恵が薄いため一旦外して様子見

## Test plan
- [ ] tmux サーバを再起動し、起動時に旧セッションが復活せず素のセッションで立ち上がること
- [ ] `prefix + r` で設定リロードしてエラーが出ないこと
- [ ] zoxide/ghq popup（`prefix + z` / `prefix + g`）からのセッション作成が引き続き動くこと
- [ ] ステータスバー（catppuccin / cpu / battery など）が崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)