### PR TITLE
feat(go): manage Go dev tools via mise

### DIFF
--- a/dot_config/cspell/user.txt
+++ b/dot_config/cspell/user.txt
@@ -46,3 +46,13 @@ actix
 cicd
 toset
 deno
+cweill
+gotests
+fatih
+gomodifytags
+segmentio
+golines
+govulncheck
+honnef
+mvdan
+gofumpt

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -38,6 +38,7 @@ zig = "latest"
 
 "aqua:anthropics/claude-code" = { version = "latest" }
 "aqua:aws/aws-cli" = { version = "latest", symlink_bins = true }
+"aqua:golangci/golangci-lint" = "latest"
 
 "cargo:cargo-audit" = "latest"
 "cargo:cargo-chef" = "latest"
@@ -59,11 +60,20 @@ zig = "latest"
 "cargo:stylua" = "latest"
 "cargo:usage-cli" = "latest"
 
+"go:github.com/cweill/gotests/gotests" = "latest"
 "go:github.com/d-kuro/gwq/cmd/gwq" = "latest"
+"go:github.com/fatih/gomodifytags" = "latest"
+"go:github.com/go-delve/delve/cmd/dlv" = "latest"
+"go:github.com/josharian/impl" = "latest"
 "go:github.com/k1LoW/git-wt" = "latest"
 "go:github.com/mattn/memo" = "latest"
 "go:github.com/rhysd/vim-startuptime" = "latest"
+"go:github.com/segmentio/golines" = "latest"
+"go:go.uber.org/mock/mockgen" = "latest"
 "go:golang.org/x/tools/gopls" = "latest"
+"go:golang.org/x/vuln/cmd/govulncheck" = "latest"
+"go:honnef.co/go/tools/cmd/staticcheck" = "latest"
+"go:mvdan.cc/gofumpt" = "latest"
 
 "npm:@astrojs/language-server" = "latest"
 "npm:@astrojs/ts-plugin" = "latest"

--- a/dot_config/nvim/lua/plugins/go.nvim.lua
+++ b/dot_config/nvim/lua/plugins/go.nvim.lua
@@ -6,6 +6,5 @@ return {
 		"nvim-treesitter/nvim-treesitter",
 	},
 	ft = { "go", "gomod" },
-	build = ':lua require("go.install").update_all_sync()', -- if you need to install/update all binaries
 	opts = {},
 }


### PR DESCRIPTION
## Summary
- Add Go CLI tooling (golangci-lint, dlv, gofumpt, staticcheck, govulncheck, mockgen, gotests, impl, gomodifytags, golines) to mise so the same versioned binaries are available from both shell/CI and Neovim.
- Use `aqua:golangci/golangci-lint` since upstream deprecates `go install` (some linters need pre-compiled binaries).
- Drop `go.nvim`'s `update_all_sync` build hook to prevent duplicate `$GOPATH/bin` installs that would shadow mise-managed versions.

## Test plan
- [x] `mise install` succeeds for all new entries
- [x] Each new tool resolves via `mise which` / `which` to a mise shim or install path
- [x] `golangci-lint version` reports the aqua-distributed binary (not a `go install` build)
- [ ] Open a Go file in Neovim and confirm gopls/format-on-save still works after dropping the build hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)