### PR TITLE
ci: extend mise fetch-remote-versions timeout to 120s

### DIFF
--- a/.github/actions/arch/action.yaml
+++ b/.github/actions/arch/action.yaml
@@ -132,9 +132,11 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
       run: |
         set -euo pipefail
         sudo -Hu builder env GITHUB_TOKEN="${GITHUB_TOKEN}" \
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT="${MISE_FETCH_REMOTE_VERSIONS_TIMEOUT}" \
           chezmoi init --apply -S "${GITHUB_WORKSPACE}"
 
     - name: Trim caches (warm mode)

--- a/.github/actions/mac/action.yaml
+++ b/.github/actions/mac/action.yaml
@@ -70,6 +70,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
       run: |
         set -euo pipefail
         chezmoi init --apply -S "${{ github.workspace }}"


### PR DESCRIPTION
## Summary
- CI が `mise install` 中に `cargo:foo = \"latest\"` のバージョン解決で crates.io API がデフォルト 20s でタイムアウトし、3回リトライ全失敗 → ビルド全体が落ちる状態だった (#203 の CI で再現、main の cron も5週連続 fail)。
- `MISE_FETCH_REMOTE_VERSIONS_TIMEOUT=120s` を `Apply chezmoi` ステップに渡してタイムアウトを伸ばす。エラーメッセージ自身が示している正規のノブ。
- arch は `sudo -Hu builder env ...` を介して chezmoi を起動しているので、env を明示的に伝播させた。

## Test plan
- [ ] PR #203 を rebase して再走させ、CI が緑になるか確認
- [ ] 次回の cron (warm-cache) が緑で完走するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)