### PR TITLE
fix(zsh): support portable Home and End keys

### DIFF
--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -21,11 +21,20 @@ setopt auto_pushd # cd したら自動的にpushdする
 setopt pushd_ignore_dups # 重複したディレクトリを追加しない
 setopt extended_glob # 高機能なワイルドカード展開を使用する
 
-bindkey '^[[1~' beginning-of-line # HOME
+# Home/End differ between terminals and multiplexers. Prefer terminfo while
+# retaining the common variants so both tmux and herdr work consistently.
+zmodload zsh/terminfo 2>/dev/null
+for key in "${terminfo[khome]}" $'\eOH' $'\e[H' $'\e[1~'; do
+  [[ -n $key ]] && bindkey "$key" beginning-of-line
+done
+for key in "${terminfo[kend]}" $'\eOF' $'\e[F' $'\e[4~'; do
+  [[ -n $key ]] && bindkey "$key" end-of-line
+done
+unset key
+
 bindkey '^[[2~' overwrite-mode # INS
 # bindkey '^[[2~' bracketed-paste  # シンプルにクリップボード貼り付けにしてしまうzsh 5.9 以降
 bindkey '^[[3~' delete-char # DEL
-bindkey '^[[4~' end-of-line # END
 bindkey '^[[5~' history-beginning-search-backward # PageUp
 bindkey '^[[6~' history-beginning-search-forward # PageDown
 


### PR DESCRIPTION
## Summary

- bind Home and End using the active terminfo entries
- retain common escape-sequence variants for tmux and herdr compatibility

## Why

After replacing tmux with herdr, Home and End produced `ESC O H` and `ESC O F`. The zsh configuration only recognized `ESC [ 1 ~` and `ESC [ 4 ~`, so ZLE treated the new sequences as undefined keys.

This keeps Home and End working consistently across terminal and multiplexer combinations without adding runtime overhead after shell initialization.

## Validation

- `zsh -n dot_config/zsh/dot_zshrc`
- verified all supported Home and End sequences resolve to `beginning-of-line` and `end-of-line`
- `git diff --check`