### PR TITLE
Switch Neovim file explorer to Snacks

### DIFF
--- a/dot_config/nvim/lua/plugins/neo-tree.nvim.lua
+++ b/dot_config/nvim/lua/plugins/neo-tree.nvim.lua
@@ -73,6 +73,7 @@ end
 return {
 	"nvim-neo-tree/neo-tree.nvim",
 	branch = "v3.x",
+	cond = false,
 	dependencies = {
 		"nvim-lua/plenary.nvim",
 		-- not strictly required, but recommended

--- a/dot_config/nvim/lua/plugins/snacks.nvim.lua
+++ b/dot_config/nvim/lua/plugins/snacks.nvim.lua
@@ -1,0 +1,27 @@
+return {
+	"folke/snacks.nvim",
+	keys = {
+		{
+			"<C-n>",
+			function()
+				Snacks.explorer()
+			end,
+			desc = "Toggle file explorer",
+		},
+	},
+	opts = {
+		explorer = {
+			enabled = true,
+			replace_netrw = false,
+		},
+		picker = {
+			enabled = true,
+			sources = {
+				explorer = {
+					hidden = true,
+					ignored = true,
+				},
+			},
+		},
+	},
+}

--- a/dot_config/yazi/yazi.toml
+++ b/dot_config/yazi/yazi.toml
@@ -1,0 +1,2 @@
+[mgr]
+show_hidden = true


### PR DESCRIPTION
## Summary

- add Snacks Explorer with lazy loading on `<C-n>`
- show hidden and git-ignored files in the explorer
- disable Neo-tree and its custom Git polling while keeping its configuration available for rollback
- add a minimal Yazi configuration that shows hidden files by default

## Why

Snacks Explorer provides more intuitive file operations and event-driven Git status updates without Neo-tree's custom 1.5-second polling loop. Yazi remains available as a standalone terminal file manager rather than a Neovim integration.

## Impact

Neovim startup does not eagerly load Snacks. Oil continues to handle directory buffers because Snacks does not replace netrw.

## Validation

- `luac -p` for the changed Neovim plugin files
- `yazi --debug` with the new configuration
- `git diff --check`
- manual verification of file and Git-status updates from another tmux/herdr pane