### PR TITLE
feat(wslg): run alacritty on Linux with GPU + Japanese IME

### DIFF
--- a/dot_config/alacritty/private_alacritty.toml
+++ b/dot_config/alacritty/private_alacritty.toml
@@ -25,16 +25,16 @@ thickness = 0.18
 size = 16
 
 [font.bold]
-family = "UDEV Gothic NF"
+family = "JetBrainsMono Nerd Font Mono"
 
 [font.bold_italic]
-family = "Hack Nerd Font Mono"
+family = "JetBrainsMono Nerd Font Mono"
 
 [font.italic]
-family = "Hack Nerd Font Mono"
+family = "JetBrainsMono Nerd Font Mono"
 
 [font.normal]
-family = "Hack Nerd Font Mono"
+family = "JetBrainsMono Nerd Font Mono"
 
 [[keyboard.bindings]]
 key = "Comma"
@@ -91,7 +91,5 @@ history = 10000
 save_to_clipboard = true
 
 [terminal.shell]
-# herdr は非対話シェルから起動する。zshrc を読ませないことで
-# ペイン内のシェルから herdr が再帰起動するのを防ぐ。
-args = ["-lc", "herdr"]
+args = ["-lc", "unset HERDR_ENV; pgrep -x fcitx5 >/dev/null || fcitx5 --disable=waylandim --disable=wayland -d; exec herdr"]
 program = "zsh"

--- a/dot_config/yay/extra-packages
+++ b/dot_config/yay/extra-packages
@@ -31,6 +31,7 @@ man-pages
 mise
 mold
 nfs-utils
+noto-fonts-cjk
 noto-fonts-emoji
 nvim
 pinentry

--- a/dot_config/yay/extra-packages
+++ b/dot_config/yay/extra-packages
@@ -1,3 +1,4 @@
+alacritty
 ansible
 aws-session-manager-plugin
 base-devel
@@ -9,6 +10,10 @@ clang
 downgrade
 eva
 eza
+fcitx5
+fcitx5-configtool
+fcitx5-gtk
+fcitx5-mozc
 fd
 fuse3
 fzf
@@ -36,6 +41,7 @@ reflector
 ripgrep
 starship
 tmux
+ttf-jetbrains-mono-nerd
 trash-cli
 tree-sitter-cli
 unzip

--- a/dot_config/yay/extra-packages
+++ b/dot_config/yay/extra-packages
@@ -31,6 +31,7 @@ man-pages
 mise
 mold
 nfs-utils
+noto-fonts-emoji
 nvim
 pinentry
 podman

--- a/dot_config/zsh/dot_zshenv
+++ b/dot_config/zsh/dot_zshenv
@@ -104,3 +104,12 @@ fi
 typeset -gx VISUAL=$EDITOR
 typeset -gx GIT_EDITOR=$EDITOR
 typeset -gx SUDO_EDITOR=$EDITOR
+
+# WSLg: X11 (XWayland) 経由で GPU + IME を両立させる
+if [[ -e /dev/dxg ]]; then
+  export WAYLAND_DISPLAY=
+  export GALLIUM_DRIVER=d3d12
+  export XMODIFIERS=@im=fcitx
+  export GTK_IM_MODULE=fcitx
+  export QT_IM_MODULE=fcitx
+fi


### PR DESCRIPTION
## Summary
- WSLg 上で Linux 版 alacritty を D3D12 GPU アクセラレーション付きで動作させる
- fcitx5-mozc による日本語入力を XIM 経由で有効化（WAYLAND_DISPLAY を空にして XWayland 経路を使用）
- フォントを JetBrains Mono Nerd Font に統一し、noto-fonts-cjk / noto-fonts-emoji も追加

## Test plan
- [x] `alacritty` が WSLg 上で GPU (D3D12) 描画で起動する
- [x] 日本語入力（fcitx5-mozc）が動作する
- [x] Nerd Font アイコン・絵文字・CJK 文字が正常に表示される
- [x] herdr が正常に起動/アタッチする
- [x] Windows ランチャー（.vbs）から起動できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)