### PR TITLE
fix(wsl): defer Windows PATH and work around fcitx5 popup ghosting

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -38,6 +38,11 @@ Library
 .config/systemd
 {{ end }}
 
+{{ if not (contains "microsoft" (lower .chezmoi.kernel.osrelease)) }}
+.local/bin/explorer.exe
+.local/bin/rundll32.exe
+{{ end }}
+
 {{ if eq .chezmoi.os "windows" }}
 .asdf*
 # .bashrc

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,6 +1,7 @@
 README.md
 theme.png
 images
+.workarounds
 
 .vscode
 .github

--- a/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/PKGBUILD
+++ b/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/PKGBUILD
@@ -1,0 +1,49 @@
+# TEMPORARY: Arch Linux fcitx5 5.1.21-1 with the WSLg candidate-window workaround.
+# Upstream issue: https://github.com/microsoft/wslg/issues/1495
+
+pkgname=fcitx5
+pkgver=5.1.21
+_dictver=20121020
+pkgrel=1.1
+pkgdesc="Next generation of fcitx, cross-platform input method framework"
+arch=('x86_64')
+url="https://github.com/fcitx/fcitx5"
+license=('LGPL-2.1-or-later AND Unicode-DFS-2016')
+conflicts=('fcitx')
+groups=('fcitx5-im')
+depends=('cairo' 'enchant' 'iso-codes' 'libgl' 'libxkbcommon-x11' 'pango' 'systemd' 'wayland'
+         'xcb-imdkit' 'xcb-util-wm' 'libxkbfile' 'gdk-pixbuf2' 'yoga')
+makedepends=('git' 'extra-cmake-modules' 'ninja' 'nlohmann-json' 'plasma-wayland-protocols' 'wayland-protocols')
+source=("git+https://github.com/fcitx/fcitx5.git#tag=$pkgver?signed"
+        "https://download.fcitx-im.org/data/en_dict-$_dictver.tar.gz"
+        "wslg-keep-candidate-window-mapped.patch")
+noextract=("en_dict-$_dictver.tar.gz")
+sha512sums=('7c692ce6bfc7c6cc27ebc6040e8a2ee8be496cce99575e64b6e1ba3b9eb066dfa4288032568d54b8c8f4b26219b39295ef2b49c0579e20d088b9c875bf801b80'
+            '8418bd02492bfd786c0fab93be4400ef027ec8e9fac02220cc1f653f5eb67f54573a6a84a15baba19bb34ab892745c87df16499d6304ea75009131e2ab3b97f2'
+            '33303e7f0d441325b785d2524329eb3c2f746e86e7e1bc0cf705d6c81f95b9fd2293c4669ae2b058cf84a516238f4186d4c8def925eaccf5b5a5b05a569f115d')
+validpgpkeys=('2CC8A0609AD2A479C65B6D5C8E8B898CBF2412F9')
+
+prepare() {
+  mv en_dict-$_dictver.tar.gz fcitx5/src/modules/spell/en_dict-$_dictver.tar.gz
+  grep "SPELL_EN_DICT_VER $_dictver" fcitx5/src/modules/spell/CMakeLists.txt
+  patch -d fcitx5 -Np1 -i ../wslg-keep-candidate-window-mapped.patch
+}
+
+build() {
+  cd fcitx5
+  cmake -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LIBEXECDIR=/usr/lib \
+        -DUSE_SYSTEM_YOGA=ON .
+  ninja
+}
+
+check() {
+  cd fcitx5
+  ninja test
+}
+
+package() {
+  cd fcitx5
+  DESTDIR="$pkgdir" ninja install
+  install -Dm644 LICENSES/Unicode-DFS-2016.txt -t "$pkgdir"/usr/share/licenses/$pkgname/
+}

--- a/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/README.md
+++ b/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/README.md
@@ -1,0 +1,21 @@
+# DELETE THIS DIRECTORY WHEN WSLg #1495 IS FIXED
+
+This is a temporary local build of fcitx5 that avoids stale candidate
+windows under WSLg.
+
+Upstream issue: https://github.com/microsoft/wslg/issues/1495
+
+Install:
+
+```sh
+sh ./.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/fcitx5-wslg-workaround install
+```
+
+Restore the official Arch package:
+
+```sh
+sh ./.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/fcitx5-wslg-workaround rollback
+```
+
+Once the upstream issue is fixed, restore the official package and delete
+this entire directory. Nothing in this directory is permanent configuration.

--- a/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/fcitx5-wslg-workaround
+++ b/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/fcitx5-wslg-workaround
@@ -1,0 +1,166 @@
+#!/bin/sh
+set -eu
+
+readonly upstream_version="5.1.21-1"
+readonly patched_version="5.1.21-1.1"
+readonly signing_key="2CC8A0609AD2A479C65B6D5C8E8B898CBF2412F9"
+readonly rollback_sha256="d5117c44026445c80aa7ea85a80c447c5f61f7ae64a910a684fbb29fea59fd36"
+data_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+readonly data_dir
+readonly cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/fcitx5-wslg-workaround"
+
+usage() {
+    cat <<EOF
+Usage: ${0##*/} install|status|rollback
+
+Build and install the fcitx5 workaround for microsoft/wslg#1495.
+The recipe is pinned to Arch package ${upstream_version}.
+EOF
+}
+
+installed_version() {
+    pacman -Q fcitx5 2>/dev/null | awk '{ print $2 }'
+}
+
+require_wsl_arch() {
+    if [ ! -e /dev/dxg ]; then
+        printf '%s\n' "error: this workaround is only intended for WSLg" >&2
+        exit 1
+    fi
+    if ! command -v pacman >/dev/null 2>&1; then
+        printf '%s\n' "error: pacman is required" >&2
+        exit 1
+    fi
+    if [ "$(id -u)" -eq 0 ]; then
+        printf '%s\n' "error: run as a regular user; the script invokes sudo when needed" >&2
+        exit 1
+    fi
+}
+
+find_official_package() {
+    find "$cache_dir" /var/cache/pacman/pkg -maxdepth 1 -type f \
+        -name "fcitx5-${upstream_version}-x86_64.pkg.tar.*" ! -name '*.sig' \
+        -print 2>/dev/null | head -n 1
+}
+
+verify_rollback_package() {
+    package_path=$1
+    printf '%s  %s\n' "$rollback_sha256" "$package_path" | sha256sum -c -
+}
+
+save_rollback_package() {
+    mkdir -p "$cache_dir"
+    rollback_package="$(find_official_package || true)"
+    if [ -z "$rollback_package" ]; then
+        archive_base="https://archive.archlinux.org/packages/f/fcitx5/fcitx5-${upstream_version}-x86_64.pkg.tar.zst"
+        rollback_package="$cache_dir/fcitx5-${upstream_version}-x86_64.pkg.tar.zst"
+        curl -fL "$archive_base" -o "$rollback_package"
+        curl -fL "$archive_base.sig" -o "$rollback_package.sig"
+        verify_rollback_package "$rollback_package"
+        pacman-key --verify "$rollback_package.sig" "$rollback_package"
+        return
+    fi
+    verify_rollback_package "$rollback_package"
+    case "$rollback_package" in
+        "$cache_dir"/*) ;;
+        *)
+            cp -p "$rollback_package" "$cache_dir/"
+            ;;
+    esac
+}
+
+install_workaround() {
+    require_wsl_arch
+
+    current_version="$(installed_version || true)"
+    case "$current_version" in
+        "$patched_version")
+            printf 'fcitx5 %s is already installed\n' "$patched_version"
+            return
+            ;;
+        "$upstream_version") ;;
+        *)
+            printf 'error: expected fcitx5 %s, found %s\n' \
+                "$upstream_version" "${current_version:-not installed}" >&2
+            exit 1
+            ;;
+    esac
+
+    for command_name in curl git gpg makepkg pacman-key patch sha256sum sudo; do
+        if ! command -v "$command_name" >/dev/null 2>&1; then
+            printf 'error: required command is missing: %s\n' "$command_name" >&2
+            exit 1
+        fi
+    done
+
+    save_rollback_package
+
+    build_dir="$(mktemp -d "${TMPDIR:-/tmp}/fcitx5-wslg-workaround.XXXXXX")"
+    missing_deps=
+    cleanup() {
+        rm -rf "$build_dir"
+        if [ -n "$missing_deps" ]; then
+            # shellcheck disable=SC2086
+            sudo pacman -Rns --noconfirm $missing_deps || true
+        fi
+    }
+    trap cleanup EXIT HUP INT TERM
+
+    cp "$data_dir/PKGBUILD" "$data_dir/wslg-keep-candidate-window-mapped.patch" "$build_dir/"
+
+    missing_deps="$(pacman -T \
+        extra-cmake-modules ninja nlohmann-json plasma-wayland-protocols wayland-protocols |
+        sed 's/[<>=].*$//' | tr '\n' ' ')"
+    if [ -n "$missing_deps" ]; then
+        # shellcheck disable=SC2086
+        sudo pacman -S --asdeps --needed --noconfirm $missing_deps
+    fi
+
+    if ! gpg --list-keys "$signing_key" >/dev/null 2>&1; then
+        gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$signing_key"
+    fi
+
+    (
+        cd "$build_dir"
+        makepkg --cleanbuild --clean --noconfirm
+    )
+
+    package_path="$(find "$build_dir" -maxdepth 1 -type f \
+        -name "fcitx5-${patched_version}-x86_64.pkg.tar.*" ! -name '*.sig' \
+        -print | head -n 1)"
+    if [ -z "$package_path" ]; then
+        printf 'error: built fcitx5 %s package was not found\n' "$patched_version" >&2
+        exit 1
+    fi
+    sudo pacman -U --noconfirm "$package_path"
+    printf '%s\n' "installed fcitx5 ${patched_version}; run 'wsl --shutdown' from PowerShell"
+}
+
+rollback_workaround() {
+    require_wsl_arch
+    rollback_package="$(find_official_package || true)"
+    if [ -z "$rollback_package" ]; then
+        printf '%s\n' "error: no cached fcitx5 ${upstream_version} rollback package found" >&2
+        exit 1
+    fi
+    verify_rollback_package "$rollback_package"
+    sudo pacman -U --noconfirm "$rollback_package"
+    printf '%s\n' "restored fcitx5 ${upstream_version}; run 'wsl --shutdown' from PowerShell"
+}
+
+show_status() {
+    current_version="$(installed_version || true)"
+    printf 'installed: %s\n' "${current_version:-not installed}"
+    if rollback_package="$(find_official_package || true)" && [ -n "$rollback_package" ]; then
+        printf 'rollback:  %s\n' "$rollback_package"
+    else
+        printf '%s\n' "rollback:  unavailable"
+    fi
+}
+
+case "${1:-}" in
+    install) install_workaround ;;
+    status) show_status ;;
+    rollback) rollback_workaround ;;
+    *) usage >&2; exit 2 ;;
+esac

--- a/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/wslg-keep-candidate-window-mapped.patch
+++ b/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/wslg-keep-candidate-window-mapped.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ui/classic/xcbinputwindow.cpp b/src/ui/classic/xcbinputwindow.cpp
+index b35ed26..c507127 100644
+--- a/src/ui/classic/xcbinputwindow.cpp
++++ b/src/ui/classic/xcbinputwindow.cpp
+@@ -178,7 +178,7 @@ void XCBInputWindow::update(InputContext *inputContext) {
+     auto [width, height] = InputWindow::update(inputContext);
+     if (!visible()) {
+         if (oldVisible) {
+-            xcb_unmap_window(ui_->connection(), wid_);
++            resize(1, 1);
+             hoverIndex_ = -1;
+         }
+         return;

--- a/dot_config/private_fcitx5/private_conf/classicui.conf
+++ b/dot_config/private_fcitx5/private_conf/classicui.conf
@@ -1,0 +1,4 @@
+# 候補ウィンドウのフォント。デフォルトの "Sans 10" は fontconfig 任せで
+# 解決先が環境によって揺れるため、日本語フォントを明示する。
+# サイズは alacritty の font size = 16 に対して見やすい値。
+Font="Noto Sans CJK JP 12"

--- a/dot_config/private_fcitx5/private_conf/xim.conf
+++ b/dot_config/private_fcitx5/private_conf/xim.conf
@@ -1,0 +1,8 @@
+# On The Spot スタイルを使用 (fcitx5 の再起動が必要)
+#
+# False (デフォルト) だと変換中の文字列を alacritty に渡さず、fcitx5 が
+# 自前のポップアップウィンドウに描く。WSLg では override-redirect ウィンドウの
+# 生成・移動・再描画が XWayland 経由で RDP を通るため、これが 1 打鍵ごとに
+# 走って入力が体感で遅れる。True にすると preedit が alacritty 内に
+# インライン描画され、ポップアップの更新は候補リスト表示時だけになる。
+UseOnTheSpot=True

--- a/dot_config/zsh/defer.zsh
+++ b/dot_config/zsh/defer.zsh
@@ -275,8 +275,6 @@ tgz() {
 if grep -qE "(Microsoft|WSL)" /proc/version &>/dev/null; then
     LS_COLORS="${LS_COLORS}:ow=01;34"
     export LS_COLORS
-    export PATH=$PATH:/mnt/c/windows
-    alias II='explorer.exe'
 fi
 
 if ((${+commands[brew]})); then

--- a/dot_config/zsh/dot_zshenv
+++ b/dot_config/zsh/dot_zshenv
@@ -103,13 +103,16 @@ export NPM_DATA_DIR="$XDG_DATA_HOME/npm"
 export NPM_CACHE_DIR="$XDG_CACHE_HOME/npm"
 export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
 
-if (( $+commands[nvim] )); then
-  typeset -gx EDITOR=nvim
-elif (( $+commands[vim] )); then
-  typeset -gx EDITOR=vim
-else
-  typeset -gx EDITOR=vi
-fi
+# $+commands は PATH 全走査を起こす。非対話シェルは上の WSL ブロックで PATH を
+# 維持しているため走査が重い。実ファイルを直接見て EDITOR を決める。
+typeset -gx EDITOR=vi
+for _ed in nvim vim; do
+  if [[ -x /usr/bin/$_ed || -x /usr/local/bin/$_ed || -x /opt/homebrew/bin/$_ed || -x $HOME/.local/bin/$_ed ]]; then
+    typeset -gx EDITOR=$_ed
+    break
+  fi
+done
+unset _ed
 
 typeset -gx VISUAL=$EDITOR
 typeset -gx GIT_EDITOR=$EDITOR

--- a/dot_config/zsh/dot_zshenv
+++ b/dot_config/zsh/dot_zshenv
@@ -37,6 +37,16 @@ path=(
   $XDG_DATA_HOME/gh-red/bin(N-/)
   $path
 )
+
+# WSL: Windows 側 PATH は DrvFs アクセスが 1 ディレクトリ ~10ms かかり、19 本あると
+# $commands (PATH 全走査) だけで ~90ms 遅くなる。対話シェルでは退避しておき、
+# .zshrc の winpath / command_not_found_handler で必要になった時に戻す。
+# 非対話 (zsh -c のインライン実行) は exe を直接呼べるよう維持する。
+if [[ -o interactive ]]; then
+  typeset -ga _ZSH_WIN_PATH=( ${(M)path:#/mnt/*} )
+  path=( ${path:#/mnt/*} )
+fi
+
 export PATH
 
 # Rust

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -110,6 +110,32 @@ fi
 # Starship
 (( ${+commands[starship]} )) && eval "$(starship init zsh)"
 
+# WSL: .zshenv が退避した Windows PATH を戻す。rehash に ~90ms かかるので
+# 必要になった時だけ払う。戻すのはこのシェルのみ。
+if (( $#_ZSH_WIN_PATH )); then
+  winpath() {
+    (( $#_ZSH_WIN_PATH )) || return 0
+    path+=( $_ZSH_WIN_PATH )
+    _ZSH_WIN_PATH=()
+    rehash
+  }
+
+  # 見つからないコマンドは Windows 側かもしれないので PATH を戻して引き直す。
+  # handler は外部コマンド用に fork された subshell で動くため、戻した PATH は
+  # この 1 回で消える (zsh の仕様)。何度も呼ぶなら winpath で永続的に戻す。
+  command_not_found_handler() {
+    if (( $#_ZSH_WIN_PATH )); then
+      winpath
+      if (( $+commands[$1] )); then
+        "$@"
+        return $?
+      fi
+    fi
+    print -u2 "zsh: command not found: $1"
+    return 127
+  }
+fi
+
 # load override
 for cand in "$ZDOTDIR/zshrc.local" "$XDG_CONFIG_HOME/zsh/zshrc.local" "$HOME/zshrc.local"; do
   [[ -r $cand ]] && source "$cand" && break

--- a/dot_local/bin/symlink_explorer.exe
+++ b/dot_local/bin/symlink_explorer.exe
@@ -1,0 +1,1 @@
+/mnt/c/Windows/explorer.exe

--- a/dot_local/bin/symlink_rundll32.exe
+++ b/dot_local/bin/symlink_rundll32.exe
@@ -1,0 +1,1 @@
+/mnt/c/Windows/System32/rundll32.exe


### PR DESCRIPTION
## Summary

- Defer loading the Windows PATH in interactive shells to reduce zsh startup overhead on WSL
- Keep `explorer.exe` and `rundll32.exe` available through symlinks in `~/.local/bin`
- Add a temporary fcitx5 patch and rebuild instructions to prevent candidate window ghosting under WSLg
- Tune fcitx5 preedit and candidate display settings for WSLg

## Verification

- `zsh -n dot_config/zsh/dot_zshenv dot_config/zsh/dot_zshrc dot_config/zsh/defer.zsh`
- `sh -n` and `shellcheck` on the workaround script
- `git diff --check origin/main...HEAD`
- Confirmed on WSLg that the patched fcitx5 build eliminates IME candidate popup ghosting

## Notes

`.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/` is a temporary workaround intended to be removed as a whole once WSLg issue #1495 is fixed.