### PR TITLE
perf(zsh): reduce interactive startup latency

### DIFF
--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -81,11 +81,12 @@ typeset -g __MISE_BIN
 
 # Avoid building the full $commands hash just to locate startup dependencies.
 _zsh_find_command() {
-  local dir
+  local dir candidate
   REPLY=
-  for dir in $path; do
-    [[ -x "$dir/$1" && ! -d "$dir/$1" ]] || continue
-    REPLY="$dir/$1"
+  for dir in "$path[@]"; do
+    candidate=${dir:+$dir/}$1
+    [[ -x $candidate && ! -d $candidate ]] || continue
+    REPLY=${candidate:a}
     return 0
   done
   return 1
@@ -128,7 +129,11 @@ if _zsh_find_command starship; then
   typeset _starship_bin=$REPLY
   typeset _starship_config=${STARSHIP_CONFIG:-$XDG_CONFIG_HOME/starship.toml}
   typeset _starship_init=$XDG_CACHE_HOME/zsh/starship-init.zsh
-  typeset _starship_marker="# starship-bin: $_starship_bin"
+  typeset _starship_init_tmp="$_starship_init.tmp.$$"
+  typeset -A _starship_stat
+  zmodload zsh/stat
+  zstat -H _starship_stat -- "$_starship_bin"
+  typeset _starship_marker="# starship-bin: $_starship_bin:$_starship_stat[device]:$_starship_stat[inode]:$_starship_stat[size]:$_starship_stat[mtime]"
   typeset _starship_cached_marker=
   typeset -i _starship_cache_matches=0
   typeset -i _starship_initialized=0
@@ -147,21 +152,22 @@ if _zsh_find_command starship; then
       # Starship computes PROMPT2 eagerly; defer it until a continuation prompt is used.
       _starship_source="${_starship_source%$'\n'PROMPT2=*}"$'\n'"PROMPT2='\$(\"$_starship_bin\" prompt --continuation)'"
       if mkdir -p "${_starship_init:h}" 2>/dev/null &&
-          print -r -- "$_starship_marker"$'\n'"$_starship_source" >| "$_starship_init.tmp" 2>/dev/null &&
-          mv -f "$_starship_init.tmp" "$_starship_init" 2>/dev/null; then
+          print -r -- "$_starship_marker"$'\n'"$_starship_source" >| "$_starship_init_tmp" 2>/dev/null &&
+          mv -f "$_starship_init_tmp" "$_starship_init" 2>/dev/null; then
         _starship_cache_matches=1
       else
-        rm -f "$_starship_init.tmp" 2>/dev/null
-        eval "$_starship_source"
-        _starship_initialized=1
+        rm -f "$_starship_init_tmp" 2>/dev/null
       fi
+      # Another shell may replace the shared cache before it can be sourced.
+      eval "$_starship_source"
+      _starship_initialized=1
     fi
     unset _starship_source
   fi
 
   (( _starship_initialized || ! _starship_cache_matches )) || source "$_starship_init"
-  unset _starship_bin _starship_config _starship_init _starship_marker
-  unset _starship_cached_marker _starship_cache_matches _starship_initialized
+  unset _starship_bin _starship_config _starship_init _starship_init_tmp _starship_marker
+  unset _starship_stat _starship_cached_marker _starship_cache_matches _starship_initialized
 fi
 unfunction _zsh_find_command
 

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -128,28 +128,40 @@ if _zsh_find_command starship; then
   typeset _starship_bin=$REPLY
   typeset _starship_config=${STARSHIP_CONFIG:-$XDG_CONFIG_HOME/starship.toml}
   typeset _starship_init=$XDG_CACHE_HOME/zsh/starship-init.zsh
+  typeset _starship_marker="# starship-bin: $_starship_bin"
+  typeset _starship_cached_marker=
+  typeset -i _starship_cache_matches=0
   typeset -i _starship_initialized=0
 
-  if [[ ! -r $_starship_init || $_starship_bin -nt $_starship_init || $_starship_config -nt $_starship_init ]]; then
+  if [[ -r $_starship_init ]]; then
+    IFS= read -r _starship_cached_marker < "$_starship_init"
+    [[ $_starship_cached_marker == $_starship_marker ]] && _starship_cache_matches=1
+  fi
+
+  if (( ! _starship_cache_matches )) ||
+      [[ $_starship_bin -nt $_starship_init || $_starship_config -nt $_starship_init ]]; then
     zmodload zsh/files
 
-    typeset _starship_source="$("$_starship_bin" init zsh)"
-    # Starship computes PROMPT2 eagerly; defer it until a continuation prompt is used.
-    _starship_source="${_starship_source%$'\n'PROMPT2=*}"$'\n'"PROMPT2='\$(\"$_starship_bin\" prompt --continuation)'"
-    if mkdir -p "${_starship_init:h}" 2>/dev/null &&
-        print -r -- "$_starship_source" >| "$_starship_init.tmp" 2>/dev/null &&
-        mv -f "$_starship_init.tmp" "$_starship_init" 2>/dev/null; then
-      :
-    else
-      rm -f "$_starship_init.tmp" 2>/dev/null
-      eval "$_starship_source"
-      _starship_initialized=1
+    typeset _starship_source
+    if _starship_source="$("$_starship_bin" init zsh)"; then
+      # Starship computes PROMPT2 eagerly; defer it until a continuation prompt is used.
+      _starship_source="${_starship_source%$'\n'PROMPT2=*}"$'\n'"PROMPT2='\$(\"$_starship_bin\" prompt --continuation)'"
+      if mkdir -p "${_starship_init:h}" 2>/dev/null &&
+          print -r -- "$_starship_marker"$'\n'"$_starship_source" >| "$_starship_init.tmp" 2>/dev/null &&
+          mv -f "$_starship_init.tmp" "$_starship_init" 2>/dev/null; then
+        _starship_cache_matches=1
+      else
+        rm -f "$_starship_init.tmp" 2>/dev/null
+        eval "$_starship_source"
+        _starship_initialized=1
+      fi
     fi
     unset _starship_source
   fi
 
-  (( _starship_initialized )) || source "$_starship_init"
-  unset _starship_bin _starship_config _starship_init _starship_initialized
+  (( _starship_initialized || ! _starship_cache_matches )) || source "$_starship_init"
+  unset _starship_bin _starship_config _starship_init _starship_marker
+  unset _starship_cached_marker _starship_cache_matches _starship_initialized
 fi
 unfunction _zsh_find_command
 

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -77,13 +77,28 @@ zsh-defer '[[ -r "$XDG_CONFIG_HOME/op/plugins.sh" ]] && source "$XDG_CONFIG_HOME
 # Mise
 autoload -Uz add-zsh-hook
 typeset -g __MISE_ACTIVATED=0
+typeset -g __MISE_BIN
+
+# Avoid building the full $commands hash just to locate startup dependencies.
+_zsh_find_command() {
+  local dir
+  REPLY=
+  for dir in $path; do
+    [[ -x "$dir/$1" && ! -d "$dir/$1" ]] || continue
+    REPLY="$dir/$1"
+    return 0
+  done
+  return 1
+}
+
+_zsh_find_command mise && __MISE_BIN=$REPLY
 
 __mise_activate_once() {
   (( __MISE_ACTIVATED )) && return 0
   __MISE_ACTIVATED=1
 
   export MISE_JOBS=$(( $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1) + 1 ))
-  eval "$(mise activate zsh)"
+  eval "$("$__MISE_BIN" activate zsh)"
   if (( $+functions[mise] )); then
     # Keep a single wrapper here so token loading happens only on actual mise runs.
     functions[_mise_internal]="$functions[mise]"
@@ -92,9 +107,10 @@ __mise_activate_once() {
       _mise_internal "$@"
     }
   fi
+  unset __MISE_BIN
 }
 
-if (( $+commands[mise] )); then
+if [[ -n $__MISE_BIN ]]; then
   if [[ -o interactive ]]; then
     __mise_preexec_once() {
       __mise_activate_once
@@ -108,7 +124,34 @@ fi
 
 # 遅延ロードしない方が安全
 # Starship
-(( ${+commands[starship]} )) && eval "$(starship init zsh)"
+if _zsh_find_command starship; then
+  typeset _starship_bin=$REPLY
+  typeset _starship_config=${STARSHIP_CONFIG:-$XDG_CONFIG_HOME/starship.toml}
+  typeset _starship_init=$XDG_CACHE_HOME/zsh/starship-init.zsh
+  typeset -i _starship_initialized=0
+
+  if [[ ! -r $_starship_init || $_starship_bin -nt $_starship_init || $_starship_config -nt $_starship_init ]]; then
+    zmodload zsh/files
+
+    typeset _starship_source="$("$_starship_bin" init zsh)"
+    # Starship computes PROMPT2 eagerly; defer it until a continuation prompt is used.
+    _starship_source="${_starship_source%$'\n'PROMPT2=*}"$'\n'"PROMPT2='\$(\"$_starship_bin\" prompt --continuation)'"
+    if mkdir -p "${_starship_init:h}" 2>/dev/null &&
+        print -r -- "$_starship_source" >| "$_starship_init.tmp" 2>/dev/null &&
+        mv -f "$_starship_init.tmp" "$_starship_init" 2>/dev/null; then
+      :
+    else
+      rm -f "$_starship_init.tmp" 2>/dev/null
+      eval "$_starship_source"
+      _starship_initialized=1
+    fi
+    unset _starship_source
+  fi
+
+  (( _starship_initialized )) || source "$_starship_init"
+  unset _starship_bin _starship_config _starship_init _starship_initialized
+fi
+unfunction _zsh_find_command
 
 # WSL: .zshenv が退避した Windows PATH を戻す。rehash に ~90ms かかるので
 # 必要になった時だけ払う。戻すのはこのシェルのみ。


### PR DESCRIPTION
## Summary

- avoid eagerly building Zsh's full `$commands` hash when locating `mise` and `starship`
- cache generated Starship initialization and invalidate it when the binary or config changes
- defer Starship's continuation prompt generation until `PROMPT2` is actually rendered
- fall back to in-memory Starship initialization when the cache is not writable

## Performance

`hyperfine -w 3 -m 500 'zsh -ic exit'`:

- before: 16.4 ms
- after: 5.9-6.3 ms in the normal environment

## Verification

- `zsh -n dot_config/zsh/dot_zshrc`
- `git diff --check`
- `chezmoi diff ~/.config/zsh/.zshrc`
- real PTY verification of the normal prompt, right prompt, continuation prompt, and first-command `mise` activation
- Starship cache regeneration after config changes
- unwritable-cache fallback with no stderr output