### PR TITLE
fix(chezmoi): handle missing kernel osrelease

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -39,7 +39,7 @@ Library
 .config/systemd
 {{ end }}
 
-{{ if not (contains "microsoft" (lower .chezmoi.kernel.osrelease)) }}
+{{ if not (contains "microsoft" (lower (get .chezmoi.kernel "osrelease"))) }}
 .local/bin/explorer.exe
 .local/bin/rundll32.exe
 {{ end }}

--- a/.chezmoiscripts/run_once_after_001_install_packages.sh
+++ b/.chezmoiscripts/run_once_after_001_install_packages.sh
@@ -14,11 +14,5 @@ rustup default stable &&
 
 # Install Mise dependency
 if type mise >/dev/null 2>&1; then
-    for attempt in {1..3}; do
-        if mise install -y -v; then
-            break
-        fi
-        (( attempt < 3 )) || exit 1
-        sleep $(( attempt * 5 ))
-    done
+    mise install -y -v
 fi

--- a/.chezmoiscripts/run_once_after_001_install_packages.sh
+++ b/.chezmoiscripts/run_once_after_001_install_packages.sh
@@ -14,5 +14,11 @@ rustup default stable &&
 
 # Install Mise dependency
 if type mise >/dev/null 2>&1; then
-    mise install -y -v
+    for attempt in {1..3}; do
+        if mise install -y -v; then
+            break
+        fi
+        (( attempt < 3 )) || exit 1
+        sleep $(( attempt * 5 ))
+    done
 fi

--- a/.github/actions/arch/action.yaml
+++ b/.github/actions/arch/action.yaml
@@ -132,9 +132,14 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
+        MISE_JOBS: 4
       run: |
         set -euo pipefail
-        sudo -Hu builder env GITHUB_TOKEN="${GITHUB_TOKEN}" \
+        sudo -Hu builder env \
+          GITHUB_TOKEN="${GITHUB_TOKEN}" \
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT="${MISE_FETCH_REMOTE_VERSIONS_TIMEOUT}" \
+          MISE_JOBS="${MISE_JOBS}" \
           chezmoi init --apply -S "${GITHUB_WORKSPACE}"
 
     - name: Trim caches (warm mode)

--- a/.github/actions/arch/action.yaml
+++ b/.github/actions/arch/action.yaml
@@ -133,12 +133,14 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
+        MISE_HTTP_RETRIES: "5"
         MISE_JOBS: 4
       run: |
         set -euo pipefail
         sudo -Hu builder env \
           GITHUB_TOKEN="${GITHUB_TOKEN}" \
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT="${MISE_FETCH_REMOTE_VERSIONS_TIMEOUT}" \
+          MISE_HTTP_RETRIES="${MISE_HTTP_RETRIES}" \
           MISE_JOBS="${MISE_JOBS}" \
           chezmoi init --apply -S "${GITHUB_WORKSPACE}"
 

--- a/.github/actions/mac/action.yaml
+++ b/.github/actions/mac/action.yaml
@@ -70,6 +70,9 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
+        MISE_GITHUB_ATTESTATIONS: "false"
+        MISE_JOBS: 4
       run: |
         set -euo pipefail
         chezmoi init --apply -S "${{ github.workspace }}"

--- a/.github/actions/mac/action.yaml
+++ b/.github/actions/mac/action.yaml
@@ -72,6 +72,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
         MISE_GITHUB_ATTESTATIONS: "false"
+        MISE_HTTP_RETRIES: "5"
         MISE_JOBS: 4
       run: |
         set -euo pipefail


### PR DESCRIPTION
## Summary

- read `chezmoi.kernel.osrelease` with `get` so missing platform data is handled safely
- keep the WSL executable shim filtering behavior unchanged on Linux/WSL
- prevent `chezmoi init --apply` from failing on macOS
- limit CI mise concurrency and extend remote-version lookup timeouts to avoid crates.io request storms
- retry `mise install` so isolated registry timeouts only retry the remaining tools
- disable GitHub attestations only for the older mise bundled on the macOS runner, whose TSA verifier rejects the Herdr attestation

## Causes

1. The macOS CI runner does not expose an `osrelease` key under `.chezmoi.kernel`. Direct field access in `.chezmoiignore` therefore failed before chezmoi could apply the dotfiles.
2. Once that was fixed, all runners reached `mise install`, where the default 17-way concurrency caused repeated crates.io timeouts. The macOS runner's mise 2026.6.14 also failed Herdr verification because of a TSA timestamp verifier error.
3. After reducing concurrency, Arch installed all but three Cargo tools; those three isolated index requests still timed out. Retrying the idempotent install lets mise skip completed tools and resolve only the remaining ones.

## Verification

- rendered `.chezmoiignore` with the current WSL data
- rendered the condition with an empty kernel map to simulate the missing macOS key
- verified the mise environment overrides locally
- parsed both composite action YAML files
- `zsh -n .chezmoiscripts/run_once_after_001_install_packages.sh`
- `actionlint .github/workflows/ci.yaml`
- `git diff --check`
- macOS PR job passed after the first CI stabilization change