### PR TITLE
fix(ci): make dotfiles validation deterministic

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -39,7 +39,7 @@ Library
 .config/systemd
 {{ end }}
 
-{{ if not (contains "microsoft" (lower .chezmoi.kernel.osrelease)) }}
+{{ if not (contains "microsoft" (lower (get .chezmoi.kernel "osrelease"))) }}
 .local/bin/explorer.exe
 .local/bin/rundll32.exe
 {{ end }}

--- a/.chezmoiscripts/run_once_after_001_install_packages.sh
+++ b/.chezmoiscripts/run_once_after_001_install_packages.sh
@@ -14,11 +14,5 @@ rustup default stable &&
 
 # Install Mise dependency
 if type mise >/dev/null 2>&1; then
-    for attempt in {1..3}; do
-        if mise install -y -v; then
-            break
-        fi
-        (( attempt < 3 )) || exit 1
-        sleep $(( attempt * 5 ))
-    done
+    mise install -y -v
 fi

--- a/.chezmoiscripts/run_once_after_001_install_packages.sh
+++ b/.chezmoiscripts/run_once_after_001_install_packages.sh
@@ -14,5 +14,11 @@ rustup default stable &&
 
 # Install Mise dependency
 if type mise >/dev/null 2>&1; then
-    mise install -y -v
+    for attempt in {1..3}; do
+        if mise install -y -v; then
+            break
+        fi
+        (( attempt < 3 )) || exit 1
+        sleep $(( attempt * 5 ))
+    done
 fi

--- a/.github/actions/arch/action.yaml
+++ b/.github/actions/arch/action.yaml
@@ -133,14 +133,12 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
-        MISE_HTTP_RETRIES: "5"
         MISE_JOBS: 4
       run: |
         set -euo pipefail
         sudo -Hu builder env \
           GITHUB_TOKEN="${GITHUB_TOKEN}" \
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT="${MISE_FETCH_REMOTE_VERSIONS_TIMEOUT}" \
-          MISE_HTTP_RETRIES="${MISE_HTTP_RETRIES}" \
           MISE_JOBS="${MISE_JOBS}" \
           chezmoi init --apply -S "${GITHUB_WORKSPACE}"
 

--- a/.github/actions/arch/action.yaml
+++ b/.github/actions/arch/action.yaml
@@ -132,9 +132,14 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
+        MISE_JOBS: 4
       run: |
         set -euo pipefail
-        sudo -Hu builder env GITHUB_TOKEN="${GITHUB_TOKEN}" \
+        sudo -Hu builder env \
+          GITHUB_TOKEN="${GITHUB_TOKEN}" \
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT="${MISE_FETCH_REMOTE_VERSIONS_TIMEOUT}" \
+          MISE_JOBS="${MISE_JOBS}" \
           chezmoi init --apply -S "${GITHUB_WORKSPACE}"
 
     - name: Trim caches (warm mode)

--- a/.github/actions/arch/action.yaml
+++ b/.github/actions/arch/action.yaml
@@ -133,12 +133,14 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
+        MISE_HTTP_RETRIES: "5"
         MISE_JOBS: 4
       run: |
         set -euo pipefail
         sudo -Hu builder env \
           GITHUB_TOKEN="${GITHUB_TOKEN}" \
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT="${MISE_FETCH_REMOTE_VERSIONS_TIMEOUT}" \
+          MISE_HTTP_RETRIES="${MISE_HTTP_RETRIES}" \
           MISE_JOBS="${MISE_JOBS}" \
           chezmoi init --apply -S "${GITHUB_WORKSPACE}"
 

--- a/.github/actions/mac/action.yaml
+++ b/.github/actions/mac/action.yaml
@@ -70,6 +70,9 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
+        MISE_GITHUB_ATTESTATIONS: "false"
+        MISE_JOBS: 4
       run: |
         set -euo pipefail
         chezmoi init --apply -S "${{ github.workspace }}"

--- a/.github/actions/mac/action.yaml
+++ b/.github/actions/mac/action.yaml
@@ -72,7 +72,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
         MISE_GITHUB_ATTESTATIONS: "false"
-        MISE_HTTP_RETRIES: "5"
         MISE_JOBS: 4
       run: |
         set -euo pipefail

--- a/.github/actions/mac/action.yaml
+++ b/.github/actions/mac/action.yaml
@@ -72,6 +72,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 120s
         MISE_GITHUB_ATTESTATIONS: "false"
+        MISE_HTTP_RETRIES: "5"
         MISE_JOBS: 4
       run: |
         set -euo pipefail

--- a/.github/actions/validate/action.yaml
+++ b/.github/actions/validate/action.yaml
@@ -1,0 +1,78 @@
+name: Validate chezmoi source
+description: Install pinned chezmoi and render the source without applying it
+
+inputs:
+  chezmoi-version:
+    description: "Pinned chezmoi version"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install validation dependencies (Arch)
+      shell: bash
+      run: |
+        if command -v pacman >/dev/null 2>&1; then
+          pacman -Sy --needed --noconfirm curl ca-certificates tar gzip
+        fi
+
+    - name: Install pinned chezmoi
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        case "$(uname -s)-$(uname -m)" in
+          Darwin-arm64)
+            platform="darwin_arm64"
+            checksum_command=(shasum -a 256)
+            ;;
+          Linux-x86_64)
+            platform="linux_amd64"
+            checksum_command=(sha256sum)
+            ;;
+          *)
+            echo "Unsupported validation platform: $(uname -s)-$(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+
+        version="${{ inputs.chezmoi-version }}"
+        archive="chezmoi_${version}_${platform}.tar.gz"
+        checksums="chezmoi_${version}_checksums.txt"
+        tmpdir="$(mktemp -d)"
+        trap 'rm -rf "${tmpdir}"' EXIT
+
+        curl -fsSLo "${tmpdir}/${archive}" "https://github.com/twpayne/chezmoi/releases/download/v${version}/${archive}"
+        curl -fsSLo "${tmpdir}/${checksums}" "https://github.com/twpayne/chezmoi/releases/download/v${version}/${checksums}"
+        grep "  ${archive}$" "${tmpdir}/${checksums}" |
+          (cd "${tmpdir}" && "${checksum_command[@]}" -c -)
+        tar -xzf "${tmpdir}/${archive}" -C "${tmpdir}" chezmoi
+        install -d "${RUNNER_TEMP}/chezmoi-bin"
+        install -m 0755 "${tmpdir}/chezmoi" "${RUNNER_TEMP}/chezmoi-bin/chezmoi"
+        echo "${RUNNER_TEMP}/chezmoi-bin" >>"${GITHUB_PATH}"
+
+    - name: Render source templates
+      shell: bash
+      run: |
+        set -euo pipefail
+        validation_home="$(mktemp -d)"
+        trap 'rm -rf "${validation_home}"' EXIT
+
+        template_count=0
+        while IFS= read -r -d '' template; do
+          echo "Rendering ${template#${GITHUB_WORKSPACE}/}"
+          HOME="${validation_home}" chezmoi \
+            --source "${GITHUB_WORKSPACE}" \
+            execute-template \
+            --file "${template}" >/dev/null
+          template_count=$((template_count + 1))
+        done < <(
+          find "${GITHUB_WORKSPACE}" \
+            -path "${GITHUB_WORKSPACE}/.git" -prune -o \
+            -type f \( -name '*.tmpl' -o -name '.chezmoiignore' \) -print0
+        )
+
+        if (( template_count == 0 )); then
+          echo "No chezmoi templates found" >&2
+          exit 1
+        fi

--- a/.github/actions/validate/action.yaml
+++ b/.github/actions/validate/action.yaml
@@ -9,13 +9,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install validation dependencies (Arch)
-      shell: bash
-      run: |
-        if command -v pacman >/dev/null 2>&1; then
-          pacman -Sy --needed --noconfirm curl ca-certificates tar gzip
-        fi
-
     - name: Install pinned chezmoi
       shell: bash
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "17 10 * * 6"
@@ -22,81 +24,42 @@ env:
   CHEZMOI_VERSION: 2.69.3
 
 jobs:
-  build-mac:
-    name: build (mac)
+  validate-mac:
+    name: validate (mac)
     if: ${{ github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || !inputs.refresh_cache) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-14
-    timeout-minutes: 180
+    timeout-minutes: 10
     permissions:
       contents: read
     concurrency:
-      group: ci-build-mac-${{ github.ref_name }}
+      group: ci-validate-mac-${{ github.event.pull_request.number || github.ref_name }}
       cancel-in-progress: true
-    env:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_BUNDLE_NO_UPGRADE: 1
-      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - id: cache-epoch
-        name: Resolve cache epoch
-        shell: bash
-        run: |
-          set -euo pipefail
-          epoch="$(date -u +%G-W%V)"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.cache_epoch_override }}" ]]; then
-            epoch="${{ inputs.cache_epoch_override }}"
-          fi
-          echo "value=${epoch}" >>"${GITHUB_OUTPUT}"
-      - uses: ./.github/actions/mac
+      - uses: ./.github/actions/validate
         with:
-          cache-epoch: ${{ steps.cache-epoch.outputs.value }}
-          warm-mode: "false"
           chezmoi-version: ${{ env.CHEZMOI_VERSION }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  build-arch:
-    name: build (arch)
+  validate-arch:
+    name: validate (arch)
     if: ${{ github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || !inputs.refresh_cache) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    timeout-minutes: 10
     permissions:
       contents: read
     concurrency:
-      group: ci-build-arch-${{ github.ref_name }}
+      group: ci-validate-arch-${{ github.event.pull_request.number || github.ref_name }}
       cancel-in-progress: true
     container:
       image: archlinux@sha256:644b416048d39616bbaca93ce768ba492655c83fba80ceca65a4f59dcabdcac0
-      volumes:
-        - /mnt/pac-pkg:/var/cache/pacman/pkg
-        - /mnt/yay-pkg:/home/builder/.cache/yay
-        - /mnt/mise-pkg:/home/builder/.local/share/mise
-        - /mnt/mise-state:/home/builder/.local/state/mise
       options: >-
         --tmpfs /tmp:exec,mode=1777
         --tmpfs /var/tmp:exec,mode=1777
-        --shm-size 2g
     steps:
-      - name: Free disk space on host toolcache
-        shell: bash
-        run: rm -rf /__t/*
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - id: cache-epoch
-        name: Resolve cache epoch
-        shell: bash
-        run: |
-          set -euo pipefail
-          epoch="$(date -u +%G-W%V)"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.cache_epoch_override }}" ]]; then
-            epoch="${{ inputs.cache_epoch_override }}"
-          fi
-          echo "value=${epoch}" >>"${GITHUB_OUTPUT}"
-      - uses: ./.github/actions/arch
+      - uses: ./.github/actions/validate
         with:
-          cache-epoch: ${{ steps.cache-epoch.outputs.value }}
-          warm-mode: "false"
           chezmoi-version: ${{ env.CHEZMOI_VERSION }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   warm-cache-mac:
     name: warm-cache (mac)


### PR DESCRIPTION
## Summary

- handle missing kernel `osrelease` values in chezmoi templates
- keep conservative mise settings for scheduled full provisioning
- replace full provisioning on pushes and pull requests with isolated template rendering on macOS and Arch
- run branch CI only for pull requests to avoid duplicate push and pull-request workflows
- retain full provisioning as a scheduled or manually requested cache-warming job

## Why

Full provisioning resolves and installs dozens of `latest` tools. Transient crates.io response failures made pull-request checks non-deterministic even after increasing mise retry counts. Pull requests only need to validate that the source and platform-specific templates render; full machine provisioning remains useful as a periodic integration check.

Supersedes #214.