### PR TITLE
fix(wslg): stabilize terminal IME handling

### DIFF
--- a/.chezmoiscripts/run_onchange_after_010_setup-wslg-terminals.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_010_setup-wslg-terminals.sh.tmpl
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# fcitx5-wslg.service: {{ include "dot_config/systemd/user/fcitx5-wslg.service" | sha256sum }}
+
+{{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "arch") }}
+if [ -e /dev/dxg ]; then
+    systemctl --user daemon-reload
+    systemctl --user enable --now fcitx5-wslg.service
+fi
+{{ end }}

--- a/.chezmoiscripts/run_onchange_after_010_setup-wslg-terminals.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_010_setup-wslg-terminals.sh.tmpl
@@ -2,10 +2,26 @@
 set -eu
 
 # fcitx5-wslg.service: {{ include "dot_config/systemd/user/fcitx5-wslg.service" | sha256sum }}
+# fcitx5-wslg-workaround: {{ include ".workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/fcitx5-wslg-workaround" | sha256sum }}
+# fcitx5 PKGBUILD: {{ include ".workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/PKGBUILD" | sha256sum }}
+# WSLg #1495 patch: {{ include ".workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/wslg-keep-candidate-window-mapped.patch" | sha256sum }}
 
 {{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "arch") }}
 if [ -e /dev/dxg ]; then
+    workaround={{ .chezmoi.sourceDir | quote }}/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/fcitx5-wslg-workaround
+    fcitx5_version=$(pacman -Q fcitx5 2>/dev/null | awk '{ print $2 }')
+    case "$fcitx5_version" in
+        5.1.21-1|5.1.21-1.1)
+            sh "$workaround" install
+            ;;
+        *)
+            printf 'warning: skipping WSLg #1495 workaround for unsupported fcitx5 version %s\n' \
+                "${fcitx5_version:-not-installed}" >&2
+            ;;
+    esac
+
     systemctl --user daemon-reload
-    systemctl --user enable --now fcitx5-wslg.service
+    systemctl --user enable fcitx5-wslg.service
+    systemctl --user restart fcitx5-wslg.service
 fi
 {{ end }}

--- a/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/README.md
+++ b/.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/README.md
@@ -5,7 +5,12 @@ windows under WSLg.
 
 Upstream issue: https://github.com/microsoft/wslg/issues/1495
 
-Install:
+On Arch WSLg machines, `chezmoi apply` installs the patched package
+automatically while the installed fcitx5 version matches this pinned recipe.
+The onchange setup script skips unknown newer versions instead of downgrading
+them or failing the rest of the apply.
+
+Manual install:
 
 ```sh
 sh ./.workarounds/REMOVE_WHEN_WSLG_1495_IS_FIXED/fcitx5-wslg-workaround install

--- a/dot_config/alacritty/private_alacritty.toml
+++ b/dot_config/alacritty/private_alacritty.toml
@@ -91,5 +91,5 @@ history = 10000
 save_to_clipboard = true
 
 [terminal.shell]
-args = ["-lc", "unset HERDR_ENV; pgrep -x fcitx5 >/dev/null || fcitx5 --disable=waylandim --disable=wayland -d; exec herdr"]
+args = ["-lc", "unset HERDR_ENV; pgrep -x fcitx5 >/dev/null || fcitx5 --disable=waylandim --disable=wayland -d >/dev/null 2>&1; exec herdr"]
 program = "zsh"

--- a/dot_config/alacritty/private_alacritty.toml
+++ b/dot_config/alacritty/private_alacritty.toml
@@ -91,5 +91,5 @@ history = 10000
 save_to_clipboard = true
 
 [terminal.shell]
-args = ["-lc", "unset HERDR_ENV; pgrep -x fcitx5 >/dev/null || fcitx5 --disable=waylandim --disable=wayland -d >/dev/null 2>&1; exec herdr"]
+args = ["-lc", "unset HERDR_ENV; exec herdr"]
 program = "zsh"

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -17,9 +17,8 @@ window-padding-balance = true
 mouse-hide-while-typing = true
 scrollback-limit = 10000
 
-# Keep fcitx5 on the known-good WSLg XIM path and detach its diagnostics from
-# the terminal PTY.
-command = zsh -lc "unset HERDR_ENV; pgrep -x fcitx5 >/dev/null || fcitx5 --disable=waylandim --disable=wayland -d >/dev/null 2>&1; exec herdr"
+# fcitx5 is started after WSLg by the systemd user service.
+command = zsh -lc "unset HERDR_ENV; exec herdr"
 
 # macOS-style shortcuts, also understood by the GTK build as Super.
 macos-option-as-alt = true

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -17,8 +17,9 @@ window-padding-balance = true
 mouse-hide-while-typing = true
 scrollback-limit = 10000
 
-# Start the same interactive environment as Alacritty.
-command = zsh -lc "unset HERDR_ENV; pgrep -x fcitx5 >/dev/null || fcitx5 --disable=waylandim --disable=wayland -d; exec herdr"
+# Keep fcitx5 on the known-good WSLg XIM path and detach its diagnostics from
+# the terminal PTY.
+command = zsh -lc "unset HERDR_ENV; pgrep -x fcitx5 >/dev/null || fcitx5 --disable=waylandim --disable=wayland -d >/dev/null 2>&1; exec herdr"
 
 # macOS-style shortcuts, also understood by the GTK build as Super.
 macos-option-as-alt = true

--- a/dot_config/systemd/user/fcitx5-wslg.service
+++ b/dot_config/systemd/user/fcitx5-wslg.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Fcitx 5 input method for WSLg
+Documentation=https://fcitx-im.org/
+ConditionPathExists=/dev/dxg
+Wants=wslg-session.service
+After=wslg-session.service
+
+[Service]
+Type=simple
+Environment=DISPLAY=:0
+Environment=GALLIUM_DRIVER=d3d12
+Environment=XMODIFIERS=@im=fcitx
+Environment=GTK_IM_MODULE=fcitx
+Environment=QT_IM_MODULE=fcitx
+# WSLg rejects zwp_input_method_v1 with "permission to bind input_method denied".
+ExecStart=/usr/bin/fcitx5 --disable=waylandim --disable=wayland --replace
+Restart=always
+RestartSec=2s
+
+[Install]
+WantedBy=default.target

--- a/dot_config/zsh/dot_zshenv
+++ b/dot_config/zsh/dot_zshenv
@@ -118,7 +118,8 @@ typeset -gx VISUAL=$EDITOR
 typeset -gx GIT_EDITOR=$EDITOR
 typeset -gx SUDO_EDITOR=$EDITOR
 
-# WSLg: X11 (XWayland) 経由で GPU + IME を両立させる
+# WSLg: compositor が fcitx5 の Wayland IM 登録を拒否するため、
+# fcitx5 を必要とする GUI アプリは XWayland で動かす。
 if [[ -e /dev/dxg ]]; then
   export WAYLAND_DISPLAY=
   export GALLIUM_DRIVER=d3d12


### PR DESCRIPTION
## Summary

- run fcitx5 as a systemd user service after the WSLg session starts
- detach fcitx5 diagnostics and autosave logs from Ghostty and Alacritty PTYs
- keep WSLg GUI terminals on XWayland because WSLg rejects fcitx5 Wayland IM registration
- continue using the existing WSLg #1495 fcitx5 patch to suppress stale candidate-window frames
- rely on WSLg-generated Windows shortcuts instead of application-specific launchers

## Investigation

- reproduced Ghostty hangs during Japanese input on native Wayland with both stock and patched fcitx5
- confirmed the compositor rejects `zwp_input_method_v1` with `permission to bind input_method denied`
- confirmed the stable combination is Ghostty on XWayland with fcitx5 managed by systemd
- confirmed stock fcitx5 still reproduces the WSLg #1495 stale candidate-frame issue
- confirmed the existing one-line fcitx5 patch removes the stale frame and is independent of the Wayland hang
- confirmed the `Running autosave...` messages originate from fcitx5 and no longer share the terminal PTY

## Validation

- patched fcitx5 5.1.21-1.1 built successfully and all 47 upstream tests passed
- `fcitx5-wslg.service` is active with zero restarts
- Ghostty environment reports `DISPLAY=:0` and an empty `WAYLAND_DISPLAY`
- Japanese input remains responsive on XWayland
- rendered chezmoi setup script passes `sh -n`
- systemd user unit verification and `git diff --check` pass

## Notes

The WSLg #1495 workaround remains intentionally temporary and is replaced by normal Arch upgrades when a newer fcitx5 version is released.