### PR TITLE
fix(wslg): keep Ghostty's own window frame

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -17,8 +17,33 @@ window-padding-balance = true
 mouse-hide-while-typing = true
 scrollback-limit = 10000
 
+# WSLg: keep the libadwaita frame instead of the dated Weston 9 one.
+#
+# The trade-off is that dragging the window edges does not resize it. Ghostty
+# declares _MOTIF_WM_HINTS decorations=0x0, so Weston draws a frame but offers
+# no resize handles, and GTK4 refuses to run its own client-side resize because
+# _GTK_FRAME_EXTENTS is absent from _NET_SUPPORTED. Nobody handles the press,
+# even though _NET_FRAME_EXTENTS keeps reporting 38,38,59,38 (= GTK's 32px
+# shadow margin plus Weston's 6px border). Measured: 1600 pointer samples with
+# 45 of them inside the 6px band and several seconds held there, zero change in
+# window geometry.
+#
+# Resize with the Windows snap shortcuts (Win+Left/Right/Up) -- those run on the
+# Windows side and bypass Weston -- or with ctrl+enter below. Switch to `server`
+# if edge dragging is ever needed: Weston then sets decorations=0x1 and provides
+# a 38px grab area, at the cost of the frame's looks.
+window-decoration = client
+
 # fcitx5 is started after WSLg by the systemd user service.
 command = zsh -lc "unset HERDR_ENV; exec herdr"
+
+# WSLg: fullscreen fits the monitor it lands on (measured 1920x1200+0+0 on the
+# 1200-tall head, 3840x2160+1920+0 on the 2160-tall one) but never subtracts the
+# taskbar, so it always covers it. maximize does respect the workarea -- 2112 =
+# 2160 - 48 -- so take over the default ctrl+enter bind, which would otherwise
+# be toggle_fullscreen. Real fullscreen stays available from the command palette
+# (ctrl+shift+p).
+keybind = ctrl+enter=toggle_maximize
 
 # macOS-style shortcuts, also understood by the GTK build as Super.
 macos-option-as-alt = true


### PR DESCRIPTION
## Summary

- pin `window-decoration` to `client` so libadwaita draws the frame instead of the dated grey one Weston 9 produces
- take over `ctrl+enter`, which defaults to `toggle_fullscreen`, and bind it to `toggle_maximize` so it respects the workarea
- record the trade-off in the config: with `client`, dragging the window edges does not resize

## Investigation

- confirmed the dated frame appears with the default `window-decoration = auto` and persists with `server`, and that only `client` yields the libadwaita frame
- confirmed `client` sets `_MOTIF_WM_HINTS` decorations=`0x0`, after which Weston draws a frame but offers no resize handles
- confirmed GTK4 declines its own client-side resize because `_GTK_FRAME_EXTENTS` is absent from `_NET_SUPPORTED` (Weston 9 advertises only 7 atoms)
- confirmed `_NET_FRAME_EXTENTS` keeps reporting 38,38,59,38 -- GTK's 32px shadow margin plus Weston's 6px border -- even though nobody handles the press
- confirmed Win+Left/Right still resizes the window, since Windows snap runs on the Windows side and bypasses Weston
- ruled out maximize state as the cause of the dead edges: the same behaviour reproduces with `_NET_WM_STATE` empty
- confirmed fullscreen fits whichever monitor it lands on (1920x1200+0+0 on the 1200-tall head, 3840x2160+1920+0 on the 2160-tall one) but never subtracts the taskbar
- confirmed maximize respects the workarea at 3840x2112 (2160 - 48)
- identified microsoft/wslg#1015 as describing the maximize geometry seen here: a borderless window does not fill the workarea, and clicks inside it are offset by the resulting gap. While maximized, Weston rewrites `_NET_FRAME_EXTENTS` to 6,6,27,6 while GTK keeps its 32px shadow margin, leaving a 26px discrepancy. The issue is unrelated to display scaling

## Validation

- `ghostty +validate-config` exits 0
- recorded 1600 pointer samples over the bottom frame edge: 45 of them inside the 6px band, held there for seconds, with zero change in window geometry
- confirmed the libadwaita frame renders and Japanese input still works through fcitx5 on XWayland

## Notes

Edge resizing and the libadwaita frame cannot coexist under Weston 9. Switching `window-decoration` back to `server` restores a 38px grab area at the cost of the frame's looks, and the config comment records how to do that.

Real fullscreen remains reachable from the command palette (`ctrl+shift+p`) for the rare case where covering the taskbar is acceptable.

Per microsoft/wslg#1015 the 26px discrepancy while maximized may also offset pointer input inside the window. Whether Ghostty compensates for it has not been established yet; if it does not, avoiding maximize (Windows snap, or a fixed `window-width`/`window-height`) sidesteps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
